### PR TITLE
fix: bump chart version to 8.0.1 and add tty configuration

### DIFF
--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 8.0.0
+version: 8.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/default/templates/_common-spec_container.tpl
+++ b/charts/default/templates/_common-spec_container.tpl
@@ -20,5 +20,5 @@ args:
 {{- include "default.common-spec_container-env" . }}
 {{- include "default.common-spec_container-ports" . }}
 {{- include "default.common-spec_container-probes" . }}
-tty: {{ .Values.tty.enabled | default false }}
+tty: {{ .Values.tty.enabled }}
 {{- end }}

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -99,6 +99,9 @@ affinity: {}
 
 tolerations: []
 
+tty:
+  enabled: false
+
 # service:
 #   type: ClusterIP
 #   port: 80


### PR DESCRIPTION
- Updated Chart.yaml to version 8.0.1.
- Added tty configuration to values.yaml with default set to false.
- Adjusted _common-spec_container.tpl to reference the new tty configuration directly.